### PR TITLE
WS&480p: Add patches for RA games

### DIFF
--- a/patches/SLES-54587_8DD6DDA3.pnach
+++ b/patches/SLES-54587_8DD6DDA3.pnach
@@ -1,0 +1,10 @@
+gametitle=Raw Danger! [PAL] SLES-54587 8DD6DDA3 (NTSC Mode + Performance) (v1.0) (Souzooka)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen Hack by El_Patas
+
+//Gameplay 16:9
+patch=1,EE,003A8360,word,43E00000 //43A00000 (Increases hor. axis)
+patch=1,EE,003A8380,word,43E00000 //43A00000
+patch=1,EE,0048C12C,word,3F400000 //3F800000

--- a/patches/SLES-54587_A98B5AD6.pnach
+++ b/patches/SLES-54587_A98B5AD6.pnach
@@ -1,0 +1,10 @@
+gametitle=Raw Danger! [PAL] SLES-54587 A98B5AD6 (NTSC Mode) (v1.0) (Souzooka)
+
+[Widescreen 16:9]
+gsaspectratio=16:9
+comment=Widescreen Hack by El_Patas
+
+//Gameplay 16:9
+patch=1,EE,003A8360,word,43E00000 //43A00000 (Increases hor. axis)
+patch=1,EE,003A8380,word,43E00000 //43A00000
+patch=1,EE,0048C12C,word,3F400000 //3F800000

--- a/patches/SLUS-21621_1D1F5BA9.pnach
+++ b/patches/SLUS-21621_1D1F5BA9.pnach
@@ -1,4 +1,4 @@
-gametitle=Shin Megami Tensei: Persona 3 FES (U) SLUS-21621 94A82AAA
+gametitle=Shin Megami Tensei: Persona 3 FES (NTSC-U) SLUS-21621 1D1F5BA9 (Controllable Characters UNDUB - Original BGM)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLUS-21621_1EA75934.pnach
+++ b/patches/SLUS-21621_1EA75934.pnach
@@ -1,4 +1,4 @@
-gametitle=Shin Megami Tensei: Persona 3 FES (U) SLUS-21621 94A82AAA
+gametitle=Shin Megami Tensei: Persona 3 FES (NTSC-U) SLUS-21621 1EA75934 (Controllable Characters)
 
 [Widescreen 16:9]
 gsaspectratio=16:9

--- a/patches/SLUS-21621_97102837.pnach
+++ b/patches/SLUS-21621_97102837.pnach
@@ -1,4 +1,4 @@
-gametitle=Shin Megami Tensei: Persona 3 FES (U) SLUS-21621 94A82AAA
+gametitle=Shin Megami Tensei: Persona 3 FES (NTSC-U) SLUS-21621 97102837 (UNDUB - Original BGM)
 
 [Widescreen 16:9]
 gsaspectratio=16:9


### PR DESCRIPTION
This PR adds support for patches for some games that are only supported on the RetroAchievements site (because some RetroAchievements sets use specific XDELTA patches that change the CRC of some games).

- Raw Danger! | Zettai Zetsumei Toshi 2: Itetsuita Kiokutachi
adds support for WS
image here


- Shin Megami Tensei: Persona 3 FES
adds support for WS and additionally 480p Mode
image here

I have completed both games to make sure they work.
Persona 3 Fes with a 143+ hour game (using Controllable Characters UNDUB - Original BGM) and I made sure to play the other versions as well for at least 40 minutes.
Raw danger was also played in a game of more than 9 hours (using NTSC Mode + Performance) and I also played the other version for 1 hour.